### PR TITLE
fix: reduce webp output size

### DIFF
--- a/src/gh_space_shooter/game/renderer.py
+++ b/src/gh_space_shooter/game/renderer.py
@@ -50,7 +50,7 @@ class Renderer:
 
         combined = Image.alpha_composite(img.convert("RGBA"), overlay)
 
-        return combined.convert("RGB").convert("P", palette=Image.Palette.ADAPTIVE)
+        return combined.convert("RGB")
 
     def _draw_watermark(self, draw: ImageDraw.ImageDraw) -> None:
         """Draw watermark text in the bottom-right corner."""

--- a/src/gh_space_shooter/output/webp_provider.py
+++ b/src/gh_space_shooter/output/webp_provider.py
@@ -30,6 +30,9 @@ class WebPOutputProvider(OutputProvider):
                 append_images=frame_list[1:],
                 duration=frame_duration,
                 loop=0,
+                lossless=True,
+                quality=100,
+                method=4,
             )
 
         return buffer.getvalue()


### PR DESCRIPTION
## Summary
Reduce WebP output size.

## Changes
- `src/gh_space_shooter/game/renderer.py`: remove palette conversion.
- `src/gh_space_shooter/output/webp_provider.py`: use lossless webp.

## Results
Benchmark (from 511 contributions).

Baseline: [`fc34af3`](https://github.com/czl9707/gh-space-shooter/tree/fc34af324a462f78522233336063b1f922d6bd41) vs PR: [`58118ff`](https://github.com/qb20nh/gh-space-shooter/tree/58118ffefb944e43987ab43ccb07d5631a74602d).

| Strategy | Frames | Encode (Baseline) | Encode (PR) | Encode Change | Size (Baseline) | Size (PR) | Size Change |
|---|---:|---:|---:|---:|---:|---:|---:|
| column | 1937 | 9.06s | 16.51s | 1.82x slower | 7.64 MB | 1.38 MB | 5.54x smaller |
| row | 2456 | 11.85s | 20.71s | 1.75x slower | 9.61 MB | 1.73 MB | 5.55x smaller |

## Notes
- Pillow GIF save already converts `RGB/RGBA -> P` with an adaptive palette internally.
- No CLI/API change.
- All 33 tests pass.
