### PR TITLE
fix: bump actions/setup-python to v6 (Node.js 24)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 


### PR DESCRIPTION
## Summary
- Bumps `actions/setup-python` from `@v5` to `@v6` in `action.yml` to fix the Node.js 20 deprecation warning that every consumer of this action currently sees.

## Why
`actions/setup-python@v5` runs on Node.js 20, which GitHub is deprecating:

- **2026-06-02** — Node.js 20 actions will be force-upgraded to Node.js 24 (may break things)
- **2026-09-16** — Node.js 20 will be removed from runners entirely

Every workflow using `czl9707/gh-space-shooter` currently logs:

> `##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-python@v5.`

See the [GitHub Changelog announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

`setup-python@v6` migrated to Node.js 24 and is a drop-in replacement — same inputs, same behaviour. Release notes: https://github.com/actions/setup-python/releases/tag/v6.0.0.

## Test plan
- [x] `action.yml` still parses (single-line change)
- [ ] On merge, re-run a consumer workflow and confirm the warning is gone