### PR TITLE
fix: iterate over list copy to prevent mutation during animation loop

### DIFF
--- a/src/gh_space_shooter/game/game_state.py
+++ b/src/gh_space_shooter/game/game_state.py
@@ -67,9 +67,9 @@ class GameState(Drawable):
         self.ship.animate(delta_time)
         for enemy in self.enemies:
             enemy.animate(delta_time)
-        for bullet in self.bullets:
+        for bullet in list(self.bullets):
             bullet.animate(delta_time)
-        for explosion in self.explosions:
+        for explosion in list(self.explosions):
             explosion.animate(delta_time)
 
     def draw(self, draw: ImageDraw.ImageDraw, context: "RenderContext") -> None:


### PR DESCRIPTION
GameState.animate() iterated over self.bullets and self.explosions while Bullet.animate() and Explosion.animate() removed themselves from those lists mid-iteration. In Python, mutating a list during iteration silently skips elements — bullets and explosions would occasionally not be animated for a frame.

Fix: iterate over list(self.bullets) and list(self.explosions) to create a shallow copy at the start of each loop.