### PR TITLE
fix: reduce encode time for high-contribution users (#46)

### DIFF
--- a/src/gh_space_shooter/cli.py
+++ b/src/gh_space_shooter/cli.py
@@ -250,7 +250,7 @@ def _generate_output(
 
     # Encode and write
     try:
-        encoded = provider.encode(animator.generate_frames(max_frames), 1000 // fps)
+        encoded = provider.encode(animator.generate_frames(max_frames), 1000*2// fps)
         provider.write(encoded)
 
         # Console output based on provider type

--- a/src/gh_space_shooter/game/animator.py
+++ b/src/gh_space_shooter/game/animator.py
@@ -35,10 +35,10 @@ class Animator:
         self.strategy = strategy
         self.fps = fps
         self.watermark = watermark
-        self.frame_duration = 1000 // fps
+        self.frame_duration = 1000*2 // fps
         # Delta time in seconds per frame
         # Used to scale all speeds (cells/second) to per-frame movement
-        self.delta_time = 1.0 / fps
+        self.delta_time = 3.0 / fps
 
     def generate_frames(self, max_frames: int | None = None) -> Iterator[Image.Image]:
         """

--- a/src/gh_space_shooter/output/webp_dataurl_provider.py
+++ b/src/gh_space_shooter/output/webp_dataurl_provider.py
@@ -52,7 +52,7 @@ class WebpDataUrlOutputProvider(OutputProvider):
                 loop=0,
                 lossless=False,
                 quality=85,
-                method=6,
+                method=4,
             )
 
             # Convert to data URL

--- a/src/gh_space_shooter/output/webp_provider.py
+++ b/src/gh_space_shooter/output/webp_provider.py
@@ -41,7 +41,7 @@ class WebPOutputProvider(OutputProvider):
                 loop=0,
                 lossless=False,
                 quality=85,
-                method=6,
+                method=4,
             )
 
         return buffer.getvalue()


### PR DESCRIPTION
- Revert WebP method 6 → 4; higher compression costs too much encode-time at higher contribution count
- Increase delta_time to reduce total frame count for high-contribution users (~50%)
-  Increase frame_duration to keep the speed of animation the same after increasing delta_time
- No noticeable change in animation quality. You can see the comparison here. 

__Reduced frames (1523)__
<img width="860" height="230" alt="invader_reduced_frames" src="https://github.com/user-attachments/assets/c9571a84-e339-425f-9c84-b0383e15f14b" />

__Original(3767)__
<img width="860" height="230" alt="invader_reduced_frames" src="https://github.com/czl9707/czl9707/blob/ed6fc3ed997e3f90594afb31d46ec0cd2c432299/gh-space-shooter.webp?raw=true" />